### PR TITLE
Drop once_cell; use std lib like libcosmic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ name = "cosmic-applet-template"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0"
+rust-version = "1.80"
 
 [dependencies]
 i18n-embed-fl = "0.8"
-once_cell = "1.19.0"
 open = "5.1.3"
 rust-embed = "8.3.0"
 

--- a/src/core/localization.rs
+++ b/src/core/localization.rs
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use std::sync::LazyLock;
+
 use i18n_embed::{
     fluent::{fluent_language_loader, FluentLanguageLoader},
     LanguageLoader,
 };
-use once_cell::sync::Lazy;
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "i18n/"]
 struct Localizations;
 
-pub static LANGUAGE_LOADER: Lazy<FluentLanguageLoader> = Lazy::new(|| {
+pub static LANGUAGE_LOADER: LazyLock<FluentLanguageLoader> = LazyLock::new(|| {
     let loader: FluentLanguageLoader = fluent_language_loader!();
 
     loader


### PR DESCRIPTION
`libcosmic`'s MSRV is 1.80 which means that this project's MSRV is also 1.80. Therefore, `once_cell` can be dropped in favor of of standard library types such as `LazyLock`.

One less dependency! :partying_face: 