### PR TITLE
Don't display applets on app library

### DIFF
--- a/res/com.example.CosmicAppletTemplate.desktop
+++ b/res/com.example.CosmicAppletTemplate.desktop
@@ -8,5 +8,6 @@ Icon=com.example.CosmicAppletTemplate
 Categories=COSMIC;Utility;
 Keywords=Folder;Manager;
 MimeType=inode/directory;
+NoDisplay=true
 X-CosmicApplet=true
 X-CosmicHoverPopup=Auto


### PR DESCRIPTION
It should only show up on the panel/dock applet settings page